### PR TITLE
Fixed formatting in deployAtomicHosts.md.

### DIFF
--- a/deployAtomicHosts.md
+++ b/deployAtomicHosts.md
@@ -109,6 +109,7 @@ sudo -i
 ```
 
 **NOTE:** The below output is an example.  That is what a customer will see once there is a tree update.  What you will see in the lab is that there is "No upgrade available", this is expected.
+
 **Fedora Atomic Host**
 ```
 # atomic status


### PR DESCRIPTION
An extra newline was added to force markdown to place "Fedora Atomic Host" on it's own line just like "RHEL Atomic Host" above it.