### PR TITLE
kubernetes.md: fix kubelet config

### DIFF
--- a/configFlannel.md
+++ b/configFlannel.md
@@ -30,7 +30,7 @@ rpm -qc flannel
 # ip a
 ```
 
-* Configure flanneld to listen on the public IP of the node.  Change the ETCD_LISTEN_CLIENT_URLS from localhost to 0.0.0.0.
+* Configure etcd to listen on the public IP of the node.  Change the ETCD_LISTEN_CLIENT_URLS from localhost to 0.0.0.0.
 
 ```
 # grep ETCD_LISTEN_CLIENT_URLS /etc/etcd/etcd.conf

--- a/configKubernetes.md
+++ b/configKubernetes.md
@@ -93,8 +93,7 @@ KUBELET_ADDRESS="--address=0.0.0.0"
 # unless you used what hostname -f shows in KUBELET_ADDRESSES.
 KUBELET_HOSTNAME="--hostname_override=LOCAL_MINION_ETH0_ADDRESS"
 
-# We are (mis)using KUBE_ETCD_SERVERS.  In a future release this will be KUBE_API_SERVERS.
-KUBE_ETCD_SERVERS="--api_servers=http://MASTER_PRIV_IP_ADDR:8080"
+KUBELET_API_SERVER="--api_servers=http://MASTER_PRIV_IP_ADDR:8080"
 
 # Add your own!
 KUBELET_ARGS="--auth_path=/var/lib/kubelet/auth"


### PR DESCRIPTION
In the current version of kubernetes, we should instead use
KUBELET_API_SERVER to configure apiservers.

Related: issue #58.

Signed-off-by: Jonathan Lebon <jlebon@redhat.com>