### PR TITLE
small tweaks to virt-install invocation

### DIFF
--- a/deployAtomicHosts.md
+++ b/deployAtomicHosts.md
@@ -70,11 +70,11 @@ for i in $(seq 3); do qemu-img create -f qcow2 -o backing_file=rhel-atomic-host-
 * For Fedora or CentOS atomic hosts, we need to create cloud init data i.e. atomic0-cidata.iso in below commands. Refer https://www.technovelty.org//linux/running-cloud-images-locally.html
 
 ```
-virt-install --import --name atomic-ga-1 --os-variant=rhel7.0 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-1.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
+virt-install --import --name atomic-ga-1 --os-variant=rhel7.0 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-1.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom,readonly=on --network bridge=br0
 
-virt-install --import --name atomic-ga-2 --os-variant=rhel7.0 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-2.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
+virt-install --import --name atomic-ga-2 --os-variant=rhel7.0 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-2.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom,readonly=on --network bridge=br0
 
-virt-install --import --name atomic-ga-3 --os-variant=rhel7.0 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-3.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
+virt-install --import --name atomic-ga-3 --os-variant=rhel7.0 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-3.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom,readonly=on --network bridge=br0
 ```
 
 ##**Update VMs**

--- a/deployAtomicHosts.md
+++ b/deployAtomicHosts.md
@@ -69,8 +69,6 @@ for i in $(seq 3); do qemu-img create -f qcow2 -o backing_file=rhel-atomic-host-
 
 * For Fedora or CentOS atomic hosts, we need to create cloud init data i.e. atomic0-cidata.iso in below commands. Refer https://www.technovelty.org//linux/running-cloud-images-locally.html
 
-* Use the following commands to install the images. Note: You will need to change the bridge to match your setup, or at least confirm it matches what you have.
-
 ```
 virt-install --import --name atomic-ga-1 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-1.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
 

--- a/deployAtomicHosts.md
+++ b/deployAtomicHosts.md
@@ -65,16 +65,16 @@ gunzip rhel-atomic-host-7.qcow2.gz
 for i in $(seq 3); do qemu-img create -f qcow2 -o backing_file=rhel-atomic-host-7.qcow2 rhel-atomic-host-7-${i}.qcow2 ; done
 ```
 
-* Use the following commands to install the images. Note: You will need to change the bridge (br0) to match your setup, or at least confirm it matches what you have.
+* Use the following commands to install the images. Note: You will need to change the bridge (br0) to match your setup, or at least confirm it matches what you have. You may also want to change the os-variant parameter to match your host (e.g. sample values include "rhel7.0", "fedora21",  or "centos7.0").
 
 * For Fedora or CentOS atomic hosts, we need to create cloud init data i.e. atomic0-cidata.iso in below commands. Refer https://www.technovelty.org//linux/running-cloud-images-locally.html
 
 ```
-virt-install --import --name atomic-ga-1 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-1.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
+virt-install --import --name atomic-ga-1 --os-variant=rhel7.0 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-1.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
 
-virt-install --import --name atomic-ga-2 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-2.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
+virt-install --import --name atomic-ga-2 --os-variant=rhel7.0 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-2.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
 
-virt-install --import --name atomic-ga-3 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-3.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
+virt-install --import --name atomic-ga-3 --os-variant=rhel7.0 --ram 1024 --vcpus 2 --disk path=/var/lib/libvirt/images/rhel-atomic-host-7-3.qcow2,format=qcow2,bus=virtio --disk path=/var/lib/libvirt/images/atomic0-cidata.iso,device=cdrom --network bridge=br0 --force
 ```
 
 ##**Update VMs**


### PR DESCRIPTION
Drop the use of `--force`, and add `--os-variant` flag to squelch warnings. Remove duplicate line.